### PR TITLE
Add support of `int` and `timestamp` types

### DIFF
--- a/src/Console/GenerateFactoryCommand.php
+++ b/src/Console/GenerateFactoryCommand.php
@@ -396,6 +396,7 @@ class GenerateFactoryCommand extends Command
             'text' => $this->fakerPrefix('text', $nullable),
             'date' => $this->fakerPrefix('date()', $nullable),
             'time' => $this->fakerPrefix('time()', $nullable),
+            'timestamp' => $this->fakerPrefix('datetime()', $nullable),
             'guid' => $this->fakerPrefix('uuid', $nullable),
             'datetimetz' => $this->fakerPrefix('dateTime()', $nullable),
             'datetime' => $this->fakerPrefix('dateTime()', $nullable),

--- a/src/Console/GenerateFactoryCommand.php
+++ b/src/Console/GenerateFactoryCommand.php
@@ -400,6 +400,7 @@ class GenerateFactoryCommand extends Command
             'datetimetz' => $this->fakerPrefix('dateTime()', $nullable),
             'datetime' => $this->fakerPrefix('dateTime()', $nullable),
             'integer' => $this->fakerPrefix('randomNumber()', $nullable),
+            'int' => $this->fakerPrefix('randomNumber()', $nullable),
             'bigint' => $this->fakerPrefix('randomNumber()', $nullable),
             'smallint' => $this->fakerPrefix('randomNumber()', $nullable),
             'decimal' => $this->fakerPrefix('randomFloat()', $nullable),


### PR DESCRIPTION
At this moment database should set only integer type. Let's use alias also